### PR TITLE
abstract classes used in unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ while(true)
 }
 ```
 
+# Backward compatibility
+- **v1.1.4-unity**: all classes extending MonoBehaviour have been made abstract. To use these classes in
+a Unity project, it is necessary to generate concrete classes that inherit from these abstract classes and
+subsequently attach them to the desired Unity components. E.g., `EzyDefaultController`, `EzyEventProcessor`,
+`EzyUnityLoggerFactory`, `EzySocketConfigHolderVariable`, and `EzySocketConfigVariable`.
+
 # Used By
 
 1. [hello-csharp](https://github.com/tvd12/ezyfox-server-example/tree/master/hello-csharp)

--- a/unity/EzyDefaultController.cs
+++ b/unity/EzyDefaultController.cs
@@ -9,7 +9,7 @@ using Object = System.Object;
 
 namespace com.tvd12.ezyfoxserver.client.unity
 {
-	public class EzyDefaultController : MonoBehaviour
+	public abstract class EzyDefaultController : MonoBehaviour
 	{
 		[SerializeField]
 		private EzySocketConfigHolderVariable socketConfigHolderVariable;

--- a/unity/EzyEventProcessor.cs
+++ b/unity/EzyEventProcessor.cs
@@ -2,7 +2,7 @@
 
 namespace com.tvd12.ezyfoxserver.client.unity
 {
-	public class EzyEventProcessor : MonoBehaviour
+	public abstract class EzyEventProcessor : MonoBehaviour
 	{
 		private static EzyEventProcessor INSTANCE;
 		

--- a/unity/EzyUnityLoggerFactory.cs
+++ b/unity/EzyUnityLoggerFactory.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace com.tvd12.ezyfoxserver.client.unity
 {
-	public class EzyUnityLoggerFactory : MonoBehaviour
+	public abstract class EzyUnityLoggerFactory : MonoBehaviour
 	{
 		[SerializeField]
 		private EzyLoggerLevel loggerLevel = EzyLoggerLevel.INFO;

--- a/unity/variable/EzySocketConfigHolderVariable.cs
+++ b/unity/variable/EzySocketConfigHolderVariable.cs
@@ -2,8 +2,7 @@ using UnityEngine;
 
 namespace com.tvd12.ezyfoxserver.client.unity
 {
-	[CreateAssetMenu]
-	public class EzySocketConfigHolderVariable : EzyScriptableVariable<EzySocketConfigVariable>
+	public abstract class EzySocketConfigHolderVariable : EzyScriptableVariable<EzySocketConfigVariable>
 	{
 	}
 }

--- a/unity/variable/EzySocketConfigVariable.cs
+++ b/unity/variable/EzySocketConfigVariable.cs
@@ -3,8 +3,7 @@ using UnityEngine;
 
 namespace com.tvd12.ezyfoxserver.client.unity
 {
-	[CreateAssetMenu]
-	public class EzySocketConfigVariable : EzyScriptableVariable<
+	public abstract class EzySocketConfigVariable : EzyScriptableVariable<
 		EzySocketConfigVariable.EzySocketConfigModel
 	>
 	{


### PR DESCRIPTION
Unity reindexes assets every time we clone the ezyfox-server-csharp-client submodule, making some assets in this lib no longer compatible. Therefore, we'd better create concrete classes in specific unity project, and extends from abstract classes in this lib